### PR TITLE
Fix bug: dummy poster image not showing on details.html (see issue #79)

### DIFF
--- a/client/app/details/details.html
+++ b/client/app/details/details.html
@@ -2,7 +2,7 @@
  <div class='moviePoster'>
     <!-- If no poster_path, show dummy image -->
     <img ng-hide="!poster_path" src="http://image.tmdb.org/t/p/w185/{{poster_path}}" alt="">
-    <img ng-show="!poster_path" src="http://dummyimage.com/185x275/000/fff&text={{original_title}}" alt="">
+    <img ng-show="!poster_path" src="http://dummyimage.com/185x275/000/fff&text={{original_name}}" alt="">
  </div>
  <div class='movieDetails'>
     <h3 ng-if="original_name === undefined"> {{original_title}} </h3>


### PR DESCRIPTION
Fix for #79 
- Changes text reference for dummy poster path to {{original_name}}, not {{original_title}}not {{original_title}}
- Movie title text now shows in dummy image when there is no poster_path
